### PR TITLE
TermsOfUse Consent User Journeys for Version and DateTime

### DIFF
--- a/scenarios/aadb2c-ief-termsofuse/SignUpOrSigninToUDateTime.xml
+++ b/scenarios/aadb2c-ief-termsofuse/SignUpOrSigninToUDateTime.xml
@@ -1,0 +1,379 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TrustFrameworkPolicy
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.microsoft.com/online/cpim/schemas/2013/06"
+  PolicySchemaVersion="0.3.0.0"
+  TenantId="yourtenant.onmicrosoft.com"
+  PolicyId="B2C_1A_SignUpOrSigninToUDateTime"
+  PublicPolicyUri="http://yourtenant.onmicrosoft.com/B2C_1A_SignUpOrSigninToUDateTime">
+
+  <BasePolicy>
+    <TenantId>yourtenant.onmicrosoft.com</TenantId>
+    <PolicyId>B2C_1A_TrustFrameworkExtensions</PolicyId>
+  </BasePolicy>
+
+    <BuildingBlocks>
+        <ContentDefinitions>
+            <ContentDefinition Id="api.selfasserted.tou">
+                <LoadUri>https://cs4585b26274a94x484fx966.blob.core.windows.net/b2ccontainer/index.htm</LoadUri>
+                <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
+                <DataUri>urn:com:microsoft:aad:b2c:elements:selfasserted:1.0.0</DataUri>
+                <Metadata>
+                    <Item Key="DisplayName">Display Terms of Use Consent Agreement</Item>
+                </Metadata>
+            </ContentDefinition>
+        </ContentDefinitions>
+    </BuildingBlocks>
+    <ClaimsProviders>
+        <ClaimsProvider>
+            <DisplayName>PhoneFactor</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="PhoneFactor-Common">
+                    <EnabledForUserJourneys>OnClaimsExistence</EnabledForUserJourneys>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Token Issuer</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="JwtIssuer">
+                    <Metadata>
+                        <Item Key="IssuanceClaimPattern">AuthorityAndTenantGuid</Item>
+                        <Item Key="AuthenticationContextReferenceClaimPattern">None</Item>
+                    </Metadata>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Self Asserted</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="SelfAsserted-Input">
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="city" />
+                        <InputClaim ClaimTypeReferenceId="state" />
+                        <InputClaim ClaimTypeReferenceId="postalCode" />
+                        <InputClaim ClaimTypeReferenceId="displayName" />
+                        <InputClaim ClaimTypeReferenceId="givenName" />
+                        <InputClaim ClaimTypeReferenceId="email" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="city" />
+                        <OutputClaim ClaimTypeReferenceId="state" />
+                        <OutputClaim ClaimTypeReferenceId="postalCode" />
+                        <OutputClaim ClaimTypeReferenceId="displayName" />
+                        <OutputClaim ClaimTypeReferenceId="givenName" />
+                        <OutputClaim ClaimTypeReferenceId="email" Required="true" PartnerClaimType="Verified.Email" />
+                    </OutputClaims>
+                </TechnicalProfile>
+                <TechnicalProfile Id="SelfAsserted-Input-ToU-SignIn">
+                    <DisplayName>Self Asserted ToU</DisplayName>
+                    <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.SelfAssertedAttributeProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+                    <Metadata>
+                        <Item Key="ContentDefinitionReferenceId">api.selfasserted.tou</Item>
+                        <Item Key="TokenLifeTimeInSeconds">3600</Item>
+                        <Item Key="AllowGenerationOfClaimsWithNullValues">true</Item>
+                    </Metadata>
+                    <CryptographicKeys>
+                        <Key Id="issuer_secret" StorageReferenceId="JwtTokenSigningKeyContainer" />
+                    </CryptographicKeys>
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" DefaultValue="AgreeToTermsOfUseConsentNo" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" Required="true"/>
+                    </OutputClaims>
+                    <UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="GetNewUserAgreeToTermsOfUseConsentDateTime" />
+                    </OutputClaimsTransformations>
+                </TechnicalProfile>
+                <TechnicalProfile Id="SelfAsserted-Input-ToU-LocalAccountSignUp">
+                    <DisplayName>Self Asserted ToU</DisplayName>
+                    <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.SelfAssertedAttributeProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+                    <Metadata>
+                        <Item Key="ContentDefinitionReferenceId">api.selfasserted.tou</Item>
+                        <Item Key="TokenLifeTimeInSeconds">3600</Item>
+                        <Item Key="AllowGenerationOfClaimsWithNullValues">true</Item>
+                    </Metadata>
+                    <CryptographicKeys>
+                        <Key Id="issuer_secret" StorageReferenceId="JwtTokenSigningKeyContainer" />
+                    </CryptographicKeys>
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" DefaultValue="AgreeToTermsOfUseConsentNo" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="executed-SelfAsserted-Input" DefaultValue="true" />
+                        <OutputClaim ClaimTypeReferenceId="termsOfUseConsentRequired" DefaultValue="true" />
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" Required="true"/>
+                    </OutputClaims>
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="IsTermsOfUseConsentRequired" />
+                        <OutputClaimsTransformation ReferenceId="GetNewUserAgreeToTermsOfUseConsentDateTime" />
+                    </OutputClaimsTransformations>
+                    <UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Azure Active Directory</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="AAD-ReadCommon">
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="city" />
+                        <OutputClaim ClaimTypeReferenceId="state" />
+                        <OutputClaim ClaimTypeReferenceId="postalCode" />
+                        <OutputClaim ClaimTypeReferenceId="displayName" />
+                        <OutputClaim ClaimTypeReferenceId="givenName" />
+                        <OutputClaim ClaimTypeReferenceId="streetAddress" />
+                        <OutputClaim ClaimTypeReferenceId="termsOfUseConsentRequired" />
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentDateTime" />
+                    </OutputClaims>
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="IsTermsOfUseConsentRequired" />
+                    </OutputClaimsTransformations>
+                </TechnicalProfile>
+                <TechnicalProfile Id="AAD-WriteCommon">
+                    <PersistedClaims>
+                        <PersistedClaim ClaimTypeReferenceId="city" />
+                        <PersistedClaim ClaimTypeReferenceId="state" />
+                        <PersistedClaim ClaimTypeReferenceId="postalCode" />
+                        <PersistedClaim ClaimTypeReferenceId="displayName" />
+                        <PersistedClaim ClaimTypeReferenceId="givenName" />
+                        <PersistedClaim ClaimTypeReferenceId="extension_termsOfUseConsentDateTime" />
+                    </PersistedClaims>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Local Account</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="LocalAccountSignUpWithLogonEmailV2">
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="executed-SelfAsserted-Input" DefaultValue="true" />
+                        <!-- Note: Claims such as emails are not listed here because without a ValidationTechnicalProfile when SelfAsserted-Input is shown to the user,
+              the user will be prompted for such claims. As a result, that claim is kept in the technical profiles that have ValidationTechnicalProfile -->
+                    </OutputClaims>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+    </ClaimsProviders>
+    <UserJourneys>
+        <UserJourney Id="B2CSignUpOrSignInWithPasswordToU" NonInteractive="false">
+            <AssuranceLevel>LOA1</AssuranceLevel>
+            <PreserveOriginalAssertion>false</PreserveOriginalAssertion>
+            <OrchestrationSteps>
+                <OrchestrationStep Order="1" Type="CombinedSignInAndSignUp" ContentDefinitionReferenceId="api.signinandsignupwithpassword">
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="LocalAccountSigninEmailExchange" TechnicalProfileReferenceId="SelfAsserted-LocalAccountSignin-Email" />
+                    </ClaimsExchanges>
+                    <ClaimsProviderSelections>
+                        <ClaimsProviderSelection ValidationClaimsExchangeId="LocalAccountSigninEmailExchange" />
+                        <ClaimsProviderSelection TargetClaimsExchangeId="GoogleExchange"/>
+                    </ClaimsProviderSelections>
+                </OrchestrationStep>
+                <!-- Check if the user has selected to sign in using one of the social providers -->
+                <OrchestrationStep Order="2" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
+                            <Value>authenticationSource</Value>
+                            <Value>socialIdpAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="MicrosoftAccountExchange" TechnicalProfileReferenceId="MSA-OIDC" />
+                        <ClaimsExchange Id="GoogleExchange" TechnicalProfileReferenceId="Google-OAUTH" />
+                        <ClaimsExchange Id="FacebookExchange" TechnicalProfileReferenceId="Facebook-OAUTH" />
+                        <ClaimsExchange Id="LinkedInExchange" TechnicalProfileReferenceId="LinkedIn-OAUTH" />
+                        <ClaimsExchange Id="AmazonExchange" TechnicalProfileReferenceId="Amazon-OAUTH" />
+                        <ClaimsExchange Id="SignUpWithLogonEmailExchange" TechnicalProfileReferenceId="SelfAsserted-Input-ToU-LocalAccountSignUp" />
+                        <ClaimsExchange Id="ReadAndCreateSsoSession" TechnicalProfileReferenceId="AAD-UserReadUsingObjectId-CreateSubject" />
+                        <ClaimsExchange Id="WeiboExchange" TechnicalProfileReferenceId="Weibo-OAUTH" />
+                        <ClaimsExchange Id="QQExchange" TechnicalProfileReferenceId="QQ-OAUTH" />
+                        <ClaimsExchange Id="WeChatExchange" TechnicalProfileReferenceId="WeChat-OAUTH" />
+                        <ClaimsExchange Id="TwitterExchange" TechnicalProfileReferenceId="Twitter-OAUTH1" />
+                        <ClaimsExchange Id="GitHubExchange" TechnicalProfileReferenceId="GitHub-OAUTH2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If this is LocalAccountSignUp, the SelfAsserted-Input-ToU-LocalAccountSignUp TechnicalProfile in Step2 would have displayed the ToU page which outputs termsOfUseConsentRequired claim -->
+                <OrchestrationStep Order="3" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="LocalAccountSignUp" TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmailV2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- This step reads any user attributes that we may not have received when authenticating using ESTS so they can be sent
+          in the token. -->
+                <OrchestrationStep Order="4" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>socialIdpAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserReadWithObjectId" TechnicalProfileReferenceId="AAD-UserReadUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If social IDP authentication is used, then attempt to find the user account in the directory. -->
+                <OrchestrationStep Order="5" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>localAccountAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <!-- To cover existing SSO cookies with the old value -->
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>evoStsAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserReadUsingAlternativeSecurityId" TechnicalProfileReferenceId="AAD-UserReadUsingAlternativeSecurityId-NoError" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- Display Terms of Use consent page for any SignIn scenario based on termsOfUseConsentRequired claim -->
+                <OrchestrationStep Order="6" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Value>True</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="ShowToUConsentPageForNewUser" TechnicalProfileReferenceId="SelfAsserted-Input-ToU-SignIn" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- Show self-asserted page only if the directory does not have the user account already (i.e. we do not have an objectId).
+          This can only happen when authentication happened using a social IDP. If local account was created or authentication done
+          using ESTS in step 2, then an user account must exist in the directory by this time. -->
+                <OrchestrationStep Order="7" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>objectId</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="SelfAsserted-Social" TechnicalProfileReferenceId="SelfAsserted-Social-V2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If we displayed Terms of Use consent page and the user has consented, update the AAD directory with consent version -->
+                <OrchestrationStep Order="8" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Value>False</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWriteWithObjectId" TechnicalProfileReferenceId="AAD-UserWriteUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- The previous step (SelfAsserted-Social) could have been skipped if there were no attributes to collect from the user.
+          So, in that case, create the user in the directory if one does not already exist (verified using objectId which would be set from the last
+          step if account was created in the directory. -->
+                <OrchestrationStep Order="9" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>objectId</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWrite" TechnicalProfileReferenceId="AAD-UserWriteUsingAlternativeSecurityId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user has strongAuthenticationPhoneNumber in the directory, then use that for verification. This means user is already signed up for 2FA. -->
+                <OrchestrationStep Order="10" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>isActiveMFASession</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>strongAuthenticationPhoneNumber</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="PhoneFactor-Verify" TechnicalProfileReferenceId="PhoneFactor-Verify-V3" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user does not have an account in the directory, then attempt to step up the user. -->
+                <OrchestrationStep Order="11" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>isActiveMFASession</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>strongAuthenticationPhoneNumber</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="PhoneFactor-Input" TechnicalProfileReferenceId="PhoneFactor-Input-V3" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user stepped up and provided a fresh phone number, then write it in the directory for future authentication requests. -->
+                <OrchestrationStep Order="12" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>executed-PhoneFactor-Input</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWriteWithObjectId" TechnicalProfileReferenceId="AAD-UserWriteUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- All good. Send claims to the RP :-) -->
+                <OrchestrationStep Order="13" Type="SendClaims" CpimIssuerTechnicalProfileReferenceId="JwtIssuer" />
+            </OrchestrationSteps>
+            <ClientDefinition ReferenceId="DefaultWeb" />
+        </UserJourney>
+    </UserJourneys>
+    <RelyingParty>
+        <DefaultUserJourney ReferenceId="B2CSignUpOrSignInWithPasswordToU" />
+        <TechnicalProfile Id="PolicyProfile">
+            <DisplayName>PolicyProfile</DisplayName>
+            <Protocol Name="OpenIdConnect" />
+            <OutputClaims>
+                <OutputClaim ClaimTypeReferenceId="displayName" />
+                <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />
+                <OutputClaim ClaimTypeReferenceId="identityProvider" />
+                <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentDateTime" />
+            </OutputClaims>
+            <SubjectNamingInfo ClaimType="sub" />
+        </TechnicalProfile>
+    </RelyingParty>
+</TrustFrameworkPolicy>
+
+

--- a/scenarios/aadb2c-ief-termsofuse/SignUpOrSigninToUVersion.xml
+++ b/scenarios/aadb2c-ief-termsofuse/SignUpOrSigninToUVersion.xml
@@ -1,0 +1,411 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TrustFrameworkPolicy
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://schemas.microsoft.com/online/cpim/schemas/2013/06"
+  PolicySchemaVersion="0.3.0.0"
+  TenantId="yourtenant.onmicrosoft.com"
+  PolicyId="B2C_1A_SignUpOrSigninToUVersion"
+  PublicPolicyUri="http://yourtenant.onmicrosoft.com/B2C_1A_SignUpOrSigninToUVersion">
+
+  <BasePolicy>
+    <TenantId>yourtenant.onmicrosoft.com</TenantId>
+    <PolicyId>B2C_1A_TrustFrameworkExtensions</PolicyId>
+  </BasePolicy>
+
+    <BuildingBlocks>
+        <ContentDefinitions>
+            <ContentDefinition Id="api.selfasserted.tou">
+                <LoadUri>https://cs4585b26274a94x484fx966.blob.core.windows.net/b2ccontainer/index.htm</LoadUri>
+                <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
+                <DataUri>urn:com:microsoft:aad:b2c:elements:selfasserted:1.0.0</DataUri>
+                <Metadata>
+                    <Item Key="DisplayName">Display Terms of Use Consent Agreement</Item>
+                </Metadata>
+            </ContentDefinition>
+        </ContentDefinitions>
+    </BuildingBlocks>
+    <ClaimsProviders>
+        <ClaimsProvider>
+            <DisplayName>PhoneFactor</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="PhoneFactor-Common">
+                    <EnabledForUserJourneys>OnClaimsExistence</EnabledForUserJourneys>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Token Issuer</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="JwtIssuer">
+                    <Metadata>
+                        <Item Key="IssuanceClaimPattern">AuthorityAndTenantGuid</Item>
+                        <Item Key="AuthenticationContextReferenceClaimPattern">None</Item>
+                    </Metadata>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Self Asserted</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="SelfAsserted-Input">
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="city" />
+                        <InputClaim ClaimTypeReferenceId="state" />
+                        <InputClaim ClaimTypeReferenceId="postalCode" />
+                        <InputClaim ClaimTypeReferenceId="displayName" />
+                        <InputClaim ClaimTypeReferenceId="givenName" />
+                        <InputClaim ClaimTypeReferenceId="email" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="city" />
+                        <OutputClaim ClaimTypeReferenceId="state" />
+                        <OutputClaim ClaimTypeReferenceId="postalCode" />
+                        <OutputClaim ClaimTypeReferenceId="displayName" />
+                        <OutputClaim ClaimTypeReferenceId="givenName" />
+                        <OutputClaim ClaimTypeReferenceId="email" Required="true" PartnerClaimType="Verified.Email" />
+                    </OutputClaims>
+                </TechnicalProfile>
+                <TechnicalProfile Id="SelfAsserted-Input-ToU-SignIn">
+                    <DisplayName>Self Asserted ToU</DisplayName>
+                    <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.SelfAssertedAttributeProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+                    <Metadata>
+                        <Item Key="ContentDefinitionReferenceId">api.selfasserted.tou</Item>
+                        <Item Key="TokenLifeTimeInSeconds">3600</Item>
+                        <Item Key="AllowGenerationOfClaimsWithNullValues">true</Item>
+                    </Metadata>
+                    <CryptographicKeys>
+                        <Key Id="issuer_secret" StorageReferenceId="JwtTokenSigningKeyContainer" />
+                    </CryptographicKeys>
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" DefaultValue="AgreeToTermsOfUseConsentNo" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" Required="true"/>
+                    </OutputClaims>
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="GetNewUserAgreeToTermsOfUseConsentVersion" />
+                    </OutputClaimsTransformations>
+                    <UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />
+                </TechnicalProfile>
+                <TechnicalProfile Id="SelfAsserted-Input-ToU-LocalAccountSignUp">
+                    <DisplayName>Self Asserted ToU LocalAccountSignUp</DisplayName>
+                    <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.SelfAssertedAttributeProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+                    <Metadata>
+                        <Item Key="ContentDefinitionReferenceId">api.selfasserted.tou</Item>
+                        <Item Key="TokenLifeTimeInSeconds">3600</Item>
+                        <Item Key="AllowGenerationOfClaimsWithNullValues">true</Item>
+                    </Metadata>
+                    <CryptographicKeys>
+                        <Key Id="issuer_secret" StorageReferenceId="JwtTokenSigningKeyContainer" />
+                    </CryptographicKeys>
+                    <InputClaims>
+                        <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" DefaultValue="AgreeToTermsOfUseConsentNo" />
+                    </InputClaims>
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="executed-SelfAsserted-Input" DefaultValue="true" />
+                        <OutputClaim ClaimTypeReferenceId="termsOfUseConsentRequired" DefaultValue="true" />
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentChoice" Required="true"/>
+                    </OutputClaims>
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="GetEmptyTermsOfUseConsentVersionForNewUser" />
+                        <OutputClaimsTransformation ReferenceId="IsTermsOfUseConsentRequiredForVersion" />
+                        <OutputClaimsTransformation ReferenceId="GetNewUserAgreeToTermsOfUseConsentVersion" />
+                    </OutputClaimsTransformations>
+                    <UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Azure Active Directory</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="AAD-ReadCommon">
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="city" />
+                        <OutputClaim ClaimTypeReferenceId="state" />
+                        <OutputClaim ClaimTypeReferenceId="postalCode" />
+                        <OutputClaim ClaimTypeReferenceId="displayName" />
+                        <OutputClaim ClaimTypeReferenceId="givenName" />
+                        <OutputClaim ClaimTypeReferenceId="streetAddress" />
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" />
+                    </OutputClaims>
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="IsTermsOfUseConsentRequiredForVersion" />
+                    </OutputClaimsTransformations>
+                </TechnicalProfile>
+                <TechnicalProfile Id="AAD-WriteCommon">
+                    <PersistedClaims>
+                        <PersistedClaim ClaimTypeReferenceId="city" />
+                        <PersistedClaim ClaimTypeReferenceId="state" />
+                        <PersistedClaim ClaimTypeReferenceId="postalCode" />
+                        <PersistedClaim ClaimTypeReferenceId="displayName" />
+                        <PersistedClaim ClaimTypeReferenceId="givenName" />
+                        <PersistedClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" />
+                    </PersistedClaims>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Local Account</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="LocalAccountSignUpWithLogonEmailV2">
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="executed-SelfAsserted-Input" DefaultValue="true" />
+                        <!-- Note: Claims such as emails are not listed here because without a ValidationTechnicalProfile when SelfAsserted-Input is shown to the user,
+              the user will be prompted for such claims. As a result, that claim is kept in the technical profiles that have ValidationTechnicalProfile -->
+                    </OutputClaims>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+        <ClaimsProvider>
+            <DisplayName>Terms of Use Consent Version</DisplayName>
+            <TechnicalProfiles>
+                <TechnicalProfile Id="TermsOfUseConsentVersionForSignIn">
+                    <DisplayName>Terms of Use Consent Version for SignIn</DisplayName>
+                    <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.ClaimsTransformationProtocolProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+                    <OutputClaims>
+                        <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" />
+                    </OutputClaims>
+                    <UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />
+                    <OutputClaimsTransformations>
+                        <OutputClaimsTransformation ReferenceId="GetEmptyTermsOfUseConsentVersionForNewUser" />
+                    </OutputClaimsTransformations>
+                    <EnabledForUserJourneys>Always</EnabledForUserJourneys>
+                </TechnicalProfile>
+            </TechnicalProfiles>
+        </ClaimsProvider>
+    </ClaimsProviders>
+    <UserJourneys>
+        <UserJourney Id="B2CSignUpOrSignInWithPasswordToU" NonInteractive="false">
+            <AssuranceLevel>LOA1</AssuranceLevel>
+            <PreserveOriginalAssertion>false</PreserveOriginalAssertion>
+            <OrchestrationSteps>
+                <OrchestrationStep Order="1" Type="CombinedSignInAndSignUp" ContentDefinitionReferenceId="api.signinandsignupwithpassword">
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="LocalAccountSigninEmailExchange" TechnicalProfileReferenceId="SelfAsserted-LocalAccountSignin-Email" />
+                    </ClaimsExchanges>
+                    <ClaimsProviderSelections>
+                        <ClaimsProviderSelection ValidationClaimsExchangeId="LocalAccountSigninEmailExchange" />
+                        <ClaimsProviderSelection TargetClaimsExchangeId="GoogleExchange"/>
+                    </ClaimsProviderSelections>
+                </OrchestrationStep>
+                <!-- Check if the user has selected to sign in using one of the social providers -->
+                <OrchestrationStep Order="2" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
+                            <Value>authenticationSource</Value>
+                            <Value>socialIdpAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="MicrosoftAccountExchange" TechnicalProfileReferenceId="MSA-OIDC" />
+                        <ClaimsExchange Id="GoogleExchange" TechnicalProfileReferenceId="Google-OAUTH" />
+                        <ClaimsExchange Id="FacebookExchange" TechnicalProfileReferenceId="Facebook-OAUTH" />
+                        <ClaimsExchange Id="LinkedInExchange" TechnicalProfileReferenceId="LinkedIn-OAUTH" />
+                        <ClaimsExchange Id="AmazonExchange" TechnicalProfileReferenceId="Amazon-OAUTH" />
+                        <ClaimsExchange Id="SignUpWithLogonEmailExchange" TechnicalProfileReferenceId="SelfAsserted-Input-ToU-LocalAccountSignUp" />
+                        <ClaimsExchange Id="ReadAndCreateSsoSession" TechnicalProfileReferenceId="AAD-UserReadUsingObjectId-CreateSubject" />
+                        <ClaimsExchange Id="WeiboExchange" TechnicalProfileReferenceId="Weibo-OAUTH" />
+                        <ClaimsExchange Id="QQExchange" TechnicalProfileReferenceId="QQ-OAUTH" />
+                        <ClaimsExchange Id="WeChatExchange" TechnicalProfileReferenceId="WeChat-OAUTH" />
+                        <ClaimsExchange Id="TwitterExchange" TechnicalProfileReferenceId="Twitter-OAUTH1" />
+                        <ClaimsExchange Id="GitHubExchange" TechnicalProfileReferenceId="GitHub-OAUTH2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If this is LocalAccountSignUp, the SelfAsserted-Input-ToU-LocalAccountSignUp TechnicalProfile in Step2 would have displayed the ToU page which outputs termsOfUseConsentRequired claim -->
+                <OrchestrationStep Order="3" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="LocalAccountSignUp" TechnicalProfileReferenceId="LocalAccountSignUpWithLogonEmailV2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- For any SignIn scenarios (localAccount/socialAccount/evoSts Signin), output dummy extension_termsOfUseConsentVersion to facilitate AAD-ReadCommon. -->
+                <OrchestrationStep Order="4" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="TermsOfUseConsentVersionForUserSignIn" TechnicalProfileReferenceId="TermsOfUseConsentVersionForSignIn" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- This step reads any user attributes that we may not have received when authenticating using ESTS so they can be sent
+          in the token. -->
+                <OrchestrationStep Order="5" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>socialIdpAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserReadWithObjectId" TechnicalProfileReferenceId="AAD-UserReadUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If social IDP authentication is used, then attempt to find the user account in the directory. -->
+                <OrchestrationStep Order="6" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>localAccountAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <!-- To cover existing SSO cookies with the old value -->
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
+                            <Value>authenticationSource</Value>
+                            <Value>evoStsAuthentication</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserReadUsingAlternativeSecurityId" TechnicalProfileReferenceId="AAD-UserReadUsingAlternativeSecurityId-NoError" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- Display Terms of Use consent page for any SignIn scenario based on termsOfUseConsentRequired claim -->
+                <OrchestrationStep Order="7" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Value>True</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="ShowToUConsentPageForNewUser" TechnicalProfileReferenceId="SelfAsserted-Input-ToU-SignIn" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- Show self-asserted page only if the directory does not have the user account already (i.e. we do not have an objectId).
+          This can only happen when authentication happened using a social IDP. If local account was created or authentication done
+          using ESTS in step 2, then an user account must exist in the directory by this time. -->
+                <OrchestrationStep Order="8" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>objectId</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="SelfAsserted-Social" TechnicalProfileReferenceId="SelfAsserted-Social-V2" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If we displayed Terms of Use consent page and the user has consented, update the AAD directory with consent version -->
+                <OrchestrationStep Order="9" Type="ClaimsExchange">
+                    <Preconditions>
+                        <!-- Add condition to not execute this step for sign up scenario based on newUser claim -->
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>localAccountUserCreatedInAAD</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
+                            <Value>termsOfUseConsentRequired</Value>
+                            <Value>True</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWriteWithObjectId" TechnicalProfileReferenceId="AAD-UserWriteUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- The previous step (SelfAsserted-Social) could have been skipped if there were no attributes to collect from the user.
+          So, in that case, create the user in the directory if one does not already exist (verified using objectId which would be set from the last
+          step if account was created in the directory. -->
+                <OrchestrationStep Order="10" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>objectId</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWrite" TechnicalProfileReferenceId="AAD-UserWriteUsingAlternativeSecurityId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user has strongAuthenticationPhoneNumber in the directory, then use that for verification. This means user is already signed up for 2FA. -->
+                <OrchestrationStep Order="11" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>isActiveMFASession</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>strongAuthenticationPhoneNumber</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="PhoneFactor-Verify" TechnicalProfileReferenceId="PhoneFactor-Verify-V3" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user does not have an account in the directory, then attempt to step up the user. -->
+                <OrchestrationStep Order="12" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>isActiveMFASession</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="true">
+                            <Value>strongAuthenticationPhoneNumber</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="PhoneFactor-Input" TechnicalProfileReferenceId="PhoneFactor-Input-V3" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- If the user stepped up and provided a fresh phone number, then write it in the directory for future authentication requests. -->
+                <OrchestrationStep Order="13" Type="ClaimsExchange">
+                    <Preconditions>
+                        <Precondition Type="ClaimsExist" ExecuteActionsIf="false">
+                            <Value>executed-PhoneFactor-Input</Value>
+                            <Action>SkipThisOrchestrationStep</Action>
+                        </Precondition>
+                    </Preconditions>
+                    <ClaimsExchanges>
+                        <ClaimsExchange Id="AADUserWriteWithObjectId" TechnicalProfileReferenceId="AAD-UserWriteUsingObjectId" />
+                    </ClaimsExchanges>
+                </OrchestrationStep>
+                <!-- All good. Send claims to the RP :-) -->
+                <OrchestrationStep Order="14" Type="SendClaims" CpimIssuerTechnicalProfileReferenceId="JwtIssuer" />
+            </OrchestrationSteps>
+            <ClientDefinition ReferenceId="DefaultWeb" />
+        </UserJourney>
+    </UserJourneys>
+    <RelyingParty>
+        <DefaultUserJourney ReferenceId="B2CSignUpOrSignInWithPasswordToU" />
+        <TechnicalProfile Id="PolicyProfile">
+            <DisplayName>PolicyProfile</DisplayName>
+            <Protocol Name="OpenIdConnect" />
+            <OutputClaims>
+                <OutputClaim ClaimTypeReferenceId="displayName" />
+                <OutputClaim ClaimTypeReferenceId="givenName" />
+                <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />
+                <OutputClaim ClaimTypeReferenceId="identityProvider" />
+                <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" />
+            </OutputClaims>
+            <SubjectNamingInfo ClaimType="sub" />
+        </TechnicalProfile>
+    </RelyingParty>
+</TrustFrameworkPolicy>
+
+
+

--- a/scenarios/aadb2c-ief-termsofuse/TrustFrameworkExtensions.xml
+++ b/scenarios/aadb2c-ief-termsofuse/TrustFrameworkExtensions.xml
@@ -1,0 +1,131 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TrustFrameworkPolicy 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns="http://schemas.microsoft.com/online/cpim/schemas/2013/06" 
+  PolicySchemaVersion="0.3.0.0" 
+  TenantId="yourtenant.onmicrosoft.com" 
+  PolicyId="B2C_1A_TrustFrameworkExtensions" 
+  PublicPolicyUri="http://yourtenant.onmicrosoft.com/B2C_1A_TrustFrameworkExtensions">
+  
+  <BasePolicy>
+    <TenantId>yourtenant.onmicrosoft.com</TenantId>
+    <PolicyId>B2C_1A_TrustFrameworkBase</PolicyId>
+  </BasePolicy>
+  <BuildingBlocks>
+    <ClaimsSchema>
+       <ClaimType Id="extension_termsOfUseConsentChoice">
+        <DisplayName></DisplayName>
+        <DataType>string</DataType>
+        <UserInputType>CheckboxMultiSelect</UserInputType>
+        <Restriction>          
+          <Enumeration Text=" I agree to the Terms Of Service" Value="AgreeToTermsOfUseConsentYes" SelectByDefault="false" />
+        </Restriction>  
+      </ClaimType>
+      <ClaimType Id="extension_termsOfUseConsentDateTime">
+        <DisplayName>Terms of Use Consent Date Time</DisplayName>
+        <DataType>dateTime</DataType>
+        <AdminHelpText>Terms of Use Consent date time in UTC.</AdminHelpText>
+        <UserHelpText>Terms of Use Consent date time in UTC.</UserHelpText>
+      </ClaimType>	
+      <ClaimType Id="extension_termsOfUseConsentVersion">
+        <DisplayName>Terms of Use Consent Version</DisplayName>
+        <DataType>string</DataType>
+        <AdminHelpText>Terms of Use Consent Version.</AdminHelpText>
+        <UserHelpText>Terms of Use Consent Version.</UserHelpText>
+      </ClaimType>	
+      <ClaimType Id="termsOfUseConsentRequired">
+        <DisplayName>Terms of Use Consent Required</DisplayName>
+        <DataType>boolean</DataType>
+        <AdminHelpText>Boolean that specifies if Terms of Use Consent is required or not.</AdminHelpText>
+        <UserHelpText>Boolean that specifies if Terms of Use Consent is required or not</UserHelpText>
+      </ClaimType>
+    </ClaimsSchema>
+    <ClaimsTransformations>
+      <ClaimsTransformation Id="GetNewUserAgreeToTermsOfUseConsentDateTime" TransformationMethod="GetCurrentDateTime">
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentDateTime" TransformationClaimType="currentDateTime" />
+        </OutputClaims>
+      </ClaimsTransformation>
+      <ClaimsTransformation Id="IsTermsOfUseConsentRequired" TransformationMethod="IsTermsOfUseConsentRequired">
+        <InputClaims>
+          <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentDateTime" TransformationClaimType="termsOfUseConsentDateTime" />
+        </InputClaims>
+        <InputParameters>
+          <InputParameter Id="termsOfUseTextUpdateDateTime" DataType="dateTime" Value="2098-01-30T23:03:45" />
+        </InputParameters>
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="termsOfUseConsentRequired" TransformationClaimType="result" />
+        </OutputClaims>
+      </ClaimsTransformation>
+      <ClaimsTransformation Id="GetEmptyTermsOfUseConsentVersionForNewUser" TransformationMethod="CreateStringClaim">
+        <InputParameters>
+            <InputParameter Id="value" DataType="string" Value=""/>
+        </InputParameters>
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" TransformationClaimType="createdClaim" />
+        </OutputClaims>
+      </ClaimsTransformation>
+      <ClaimsTransformation Id="GetNewUserAgreeToTermsOfUseConsentVersion" TransformationMethod="CreateStringClaim">
+        <InputParameters>
+            <InputParameter Id="value" DataType="string" Value="V1"/>
+        </InputParameters>
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" TransformationClaimType="createdClaim" />
+        </OutputClaims>
+      </ClaimsTransformation>
+      <ClaimsTransformation Id="IsTermsOfUseConsentRequiredForVersion" TransformationMethod="CompareClaimToValue">
+        <InputClaims>
+          <InputClaim ClaimTypeReferenceId="extension_termsOfUseConsentVersion" TransformationClaimType="inputClaim1" />
+        </InputClaims>
+        <InputParameters>
+          <InputParameter Id="compareTo" DataType="string" Value="V1" />
+          <InputParameter Id="operator" DataType="string" Value="not equal" />
+          <InputParameter Id="ignoreCase" DataType="string" Value="true" />
+        </InputParameters>
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="termsOfUseConsentRequired" TransformationClaimType="outputClaim" />
+        </OutputClaims>
+      </ClaimsTransformation>
+    </ClaimsTransformations>
+  </BuildingBlocks>
+
+  <ClaimsProviders>
+
+    <ClaimsProvider>
+      <DisplayName>Facebook</DisplayName>
+      <TechnicalProfiles>
+        <TechnicalProfile Id="Facebook-OAUTH">
+          <Metadata>
+            <Item Key="client_id">facebook_clientid</Item>
+            <Item Key="scope">email public_profile</Item>
+            <Item Key="ClaimsEndpoint">https://graph.facebook.com/me?fields=id,first_name,last_name,name,email</Item>
+          </Metadata>
+        </TechnicalProfile>
+      </TechnicalProfiles>
+    </ClaimsProvider>
+
+
+    <ClaimsProvider>
+      <DisplayName>Local Account SignIn</DisplayName>
+      <TechnicalProfiles>
+         <TechnicalProfile Id="login-NonInteractive">
+          <Metadata>
+            <Item Key="client_id">ProxyIdentityExperienceFrameworkAppId</Item>
+            <Item Key="IdTokenAudience">IdentityExperienceFrameworkAppId</Item>
+          </Metadata>
+          <InputClaims>
+            <InputClaim ClaimTypeReferenceId="client_id" DefaultValue="ProxyIdentityExperienceFrameworkAppID" />
+            <InputClaim ClaimTypeReferenceId="resource_id" PartnerClaimType="resource" DefaultValue="IdentityExperienceFrameworkAppID" />
+          </InputClaims>
+        </TechnicalProfile>
+      </TechnicalProfiles>
+    </ClaimsProvider>
+
+  </ClaimsProviders>
+
+    <!--UserJourneys>
+	
+	</UserJourneys-->
+
+</TrustFrameworkPolicy>


### PR DESCRIPTION
1. LocalAccountSignUp
  a. Display ToU consent page for user to consent
  b. SelfAsserted SignUp
  c. Issue Token
2. LocalAccountSignin
  a. User Login
  b. Display ToU consent page if required based on extension_termsOfUseConsent attribute values
  c. Update AAD if ToU consent page is required
  d. Issue Token
3. SocialAccountSignUp
 a. Display login for SocialAccount
 b. Display ToU if required based on extension_termsOfUseConsent attribute values
 c. Self Asserted Social Signup
 d. Issue Token
4. SocialAccountSignin
 a. Display login for SocialAccount
 b. Display ToU if required based on extension_termsOfUseConsent attribute values
 c. Update AAD if ToU consent page is required
 d. Issue Token