### PR TITLE
(Azure CXP) Removed Identity Provider Output Claim

### DIFF
--- a/SocialAndLocalAccounts/SignUpOrSignin.xml
+++ b/SocialAndLocalAccounts/SignUpOrSignin.xml
@@ -24,7 +24,6 @@
         <OutputClaim ClaimTypeReferenceId="surname" />
         <OutputClaim ClaimTypeReferenceId="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub"/>
-        <OutputClaim ClaimTypeReferenceId="identityProvider" />
         <OutputClaim ClaimTypeReferenceId="tenantId" AlwaysUseDefaultValue="true" DefaultValue="{Policy:TenantObjectId}" />
       </OutputClaims>
       <SubjectNamingInfo ClaimType="sub" />


### PR DESCRIPTION
The Identity Provider OutputClaim throws an error on upload, removing it allows uploading the custom policy.
File SignUpOrSignIn, in localandsocial folder.