### PR TITLE
Update TrustFrameworkBase.xml

### DIFF
--- a/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -723,8 +723,6 @@
             <PersistedClaim ClaimTypeReferenceId="displayName" DefaultValue="unknown" />
             <PersistedClaim ClaimTypeReferenceId="passwordPolicies" DefaultValue="DisablePasswordExpiration" />
  
-            <PersistedClaim ClaimTypeReferenceId="Verified.strongAuthenticationPhoneNumber" PartnerClaimType="strongAuthenticationPhoneNumber" />
- 
             <!-- Optional claims. -->
             <PersistedClaim ClaimTypeReferenceId="givenName" />
             <PersistedClaim ClaimTypeReferenceId="surname" />


### PR DESCRIPTION
Please refer to this internal SO question I have posted https://stackoverflow.microsoft.com/questions/160941/localaccountsignupwithlogonemail-technical-profile-and-writing-strongauthenticat. It seems it has no sense to have the element in the technical profile, given that the strongAuthenticationPhoneNumber is written later in the user journey, and we are trying to persist it in a technical profile that is invoked before collecting it from the user. I have done tests by deleting it and there was no side-effects.