### PR TITLE
phone auth sign up: add ability to parse a phone number if it is in i…

### DIFF
--- a/scenarios/phone-number-username/TrustFrameworkBase-PhoneAndEmail.xml
+++ b/scenarios/phone-number-username/TrustFrameworkBase-PhoneAndEmail.xml
@@ -569,7 +569,13 @@
           <InputClaim ClaimTypeReferenceId="signInName" TransformationClaimType="claimToMatch" />
         </InputClaims>
         <InputParameters>
-          <InputParameter Id="matchTo" DataType="string" Value="^(?:[-()\s]*\d[-()\s]*){4,16}$" />
+            <!--
+              This regex will match a string with an optional leading "+", 4 to 16 digits, and any number of dashes, parentheses, and spaces, in any order.
+              It is intentionally overinclusive to allow the user to continue their journey with any input that might be an international or national phone number 
+              in any country with any customary punctuation/formatting. In this policy, the ConvertStringToPhoneNumberClaim claims converter will do the the final validation, 
+              ignoring the dashes, parentheses, and spaces.
+            -->
+          <InputParameter Id="matchTo" DataType="string" Value="^\+?(?:[-()\s]*\d[-()\s]*){4,16}$" />
           <InputParameter Id="outputClaimIfMatched" DataType="string" Value="isPhone" />
         </InputParameters>
         <OutputClaims>
@@ -588,6 +594,18 @@
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="validationResult" TransformationClaimType="outputClaim" />
           <OutputClaim ClaimTypeReferenceId="isEmailBoolean" TransformationClaimType="regexCompareResultClaim" />
+        </OutputClaims>
+      </ClaimsTransformation>
+      <ClaimsTransformation Id="GetNationalNumberAndCountryCodeIfInternationalFormat" TransformationMethod="GetNationalNumberAndCountryCodeFromPhoneNumberString">
+        <InputClaims>
+          <InputClaim ClaimTypeReferenceId="signInName" TransformationClaimType="phoneNumber" />
+        </InputClaims>
+        <InputParameters>
+          <InputParameter Id="throwExceptionOnFailure" DataType="boolean" Value="false" />
+        </InputParameters>
+        <OutputClaims>
+          <OutputClaim ClaimTypeReferenceId="signInName" TransformationClaimType="nationalNumber" />
+          <OutputClaim ClaimTypeReferenceId="countryCode" TransformationClaimType="countryCode" />
         </OutputClaims>
       </ClaimsTransformation>
       <ClaimsTransformation Id="SignInNameToPhoneNumber" TransformationMethod="CopyClaim">
@@ -1035,10 +1053,15 @@
           </Metadata>
           <IncludeInSso>false</IncludeInSso>
           <InputClaimsTransformations>
+            <!-- The first transformation will take the signInName entered on the first step and attempt to parse it into a national number and country code if it is in international format. This will prefill the values for 
+            the phoneNumber and countryCode claims. If it is not in international format, or it cannot be parsed, no transformation will happen; the phoneNumber claim will be prefilled with the original signInName value
+            and countryCode will not be prefilled. -->
+            <InputClaimsTransformation ReferenceId="GetNationalNumberAndCountryCodeIfInternationalFormat" />
             <InputClaimsTransformation ReferenceId="SignInNameToPhoneNumber" />
           </InputClaimsTransformations>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="phoneNumber" />
+            <InputClaim ClaimTypeReferenceId="countryCode" />
           </InputClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="countryCode" Required="true" />


### PR DESCRIPTION
…nternational format

For the phone or email sign up journey, a user can input a phone number or email address, then proceed to the appropriate sign up page. On the phone number sign up page, the user must select a country code from a dropdown in addition to the phone number entered on step 1.

With this change, the user may enter an internationally-formatted phone number on the first step so that the country code is autofilled on the second step.