### PR TITLE
Fix SM-MFA session correlation

### DIFF
--- a/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -1101,7 +1101,7 @@
           <DisplayName>Session Mananagement Provider</DisplayName>
           <Protocol Name="Proprietary" Handler="Web.TPEngine.SSO.DefaultSSOSessionProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
           <PersistedClaims>
-            <PersistedClaim ClaimTypeReferenceId="Verified.strongAuthenticationPhoneNumber" />
+            <PersistedClaim ClaimTypeReferenceId="strongAuthenticationPhoneNumber" />
           </PersistedClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="isActiveMFASession" DefaultValue="true"/>

--- a/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -847,7 +847,6 @@
             <Item Key="RaiseErrorIfClaimsPrincipalAlreadyExists">false</Item>
             <Item Key="RaiseErrorIfClaimsPrincipalDoesNotExist">true</Item>
           </Metadata>
-          <IncludeInSso>false</IncludeInSso>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="objectId" Required="true" />
           </InputClaims>
@@ -855,9 +854,12 @@
             <PersistedClaim ClaimTypeReferenceId="objectId" />
             <PersistedClaim ClaimTypeReferenceId="Verified.strongAuthenticationPhoneNumber" PartnerClaimType="strongAuthenticationPhoneNumber" />
           </PersistedClaims>
+          <OutputClaims>
+            <OutputClaim ClaimTypeReferenceId="strongAuthenticationPhoneNumber" />
+          </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
+          <UseTechnicalProfileForSessionManagement ReferenceId="SM-MFA" />
         </TechnicalProfile>
-
       </TechnicalProfiles>
     </ClaimsProvider>
 


### PR DESCRIPTION
When deriving policies from base, the MFA session (and therefore the isActiveMFASession claim) is not working correctly because it correlates with the wrong claim. 