### PR TITLE
Updated TrustFrameworkPolicy to support brackets in ContentUriTYPE

### DIFF
--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -2265,7 +2265,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="(http://|https://|~/)([\w.,@?\^=%&amp;:~+#_-]+/?)+" />
+      <xs:pattern value="(http://|https://|~/)([\w{}.,@?\^=%&amp;:~+#_-]+/?)+" />
       <xs:pattern value="urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,/\-.:=@;$_!*'%?#]+" />
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Added Brackets "{" and "}" in the ContentUriType. This was causing Visual Studio to hang on "Waiting for parsing to complete." when loading Element "LoadUri" with ClaimResolvers (e.g {Context:CorrelationId}) in ContentDefinitions. 

Example code: 

`<ContentDefinition Id="api.selfasserted">
        <LoadUri>https://test.blob.core.windows.net/b2c/IEF/{Culture:RFC5646}/unified.html</LoadUri>
        <RecoveryUri>~/common/default_page_error.html</RecoveryUri>
        <DataUri>urn:com:microsoft:aad:b2c:elements:contract:selfasserted:1.1.0</DataUri>
        <Metadata>
          <Item Key="DisplayName">Collect information from user page</Item>
        </Metadata>
      </ContentDefinition>`