### PR TITLE
Add grant_type metadata to ROPC technical profiles for JIT migration

### DIFF
--- a/LocalAccounts/TrustFrameworkBase.xml
+++ b/LocalAccounts/TrustFrameworkBase.xml
@@ -420,6 +420,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/SocialAndLocalAccounts/TrustFrameworkBase.xml
+++ b/SocialAndLocalAccounts/TrustFrameworkBase.xml
@@ -517,6 +517,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -565,6 +565,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/scenarios/aadb2c-user-migration/Sample-pre-migration-Base.xml
+++ b/scenarios/aadb2c-user-migration/Sample-pre-migration-Base.xml
@@ -442,6 +442,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>
             <Item Key="HttpBinding">POST</Item>

--- a/scenarios/password-change/TrustFrameworkExtensions.xml
+++ b/scenarios/password-change/TrustFrameworkExtensions.xml
@@ -40,6 +40,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
             <Item Key="UsePolicyInRedirectUri">false</Item>
             <Item Key="HttpBinding">POST</Item>
             <Item Key="client_id">47eb20aa-e4e1-41c7-ab14-69e72bcae4a5</Item>

--- a/scenarios/phone-number-passwordless/Phone_Email_Base.xml
+++ b/scenarios/phone-number-passwordless/Phone_Email_Base.xml
@@ -467,8 +467,8 @@
         <Parameters>
           <!--
               This regex will match a string with an optional leading "+", 4 to 16 digits, and any number of dashes, parentheses, and spaces, in any order.
-              It is intentionally overinclusive to allow the user to continue their journey with any input that might be an international or national phone number 
-              in any country with any customary punctuation/formatting. In this policy, the ConvertStringToPhoneNumberClaim claims converter will do the the final validation, 
+              It is intentionally overinclusive to allow the user to continue their journey with any input that might be an international or national phone number
+              in any country with any customary punctuation/formatting. In this policy, the ConvertStringToPhoneNumberClaim claims converter will do the the final validation,
               ignoring the dashes, parentheses, and spaces.
             -->
           <Parameter Id="RegularExpression">^\+?(?:[-()\s]*\d[-()\s]*){4,16}$</Parameter>
@@ -817,7 +817,7 @@
     </DisplayControls>
   </BuildingBlocks>
   <!--
-        A list of all the claim providers that can be used in the technical policies. If a claims provider is not listed 
+        A list of all the claim providers that can be used in the technical policies. If a claims provider is not listed
         in this section, then it cannot be used in a technical policy.
     -->
   <ClaimsProviders>
@@ -1414,6 +1414,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>
             <Item Key="HttpBinding">POST</Item>

--- a/scenarios/source/aadb2c-ief-ropc/TrustFrameworkExtensions.xml
+++ b/scenarios/source/aadb2c-ief-ropc/TrustFrameworkExtensions.xml
@@ -83,6 +83,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="logonIdentifier" PartnerClaimType="username" Required="true" DefaultValue="{OIDC:Username}"/>


### PR DESCRIPTION
This is a long-overdue update to the starterpack which enables the JIT migration feature via ROPC & REST (internal work item [737057](https://identitydivision.visualstudio.com/Identity%20CXP/_workitems/edit/737057)).  I would have sent this earlier but I wasn't aware of the update process. :-/