### PR TITLE
Added support for newUser claim to signups

### DIFF
--- a/scenarios/phone-number-passwordless/Phone_Email_Base.xml
+++ b/scenarios/phone-number-passwordless/Phone_Email_Base.xml
@@ -1,6 +1,10 @@
 <TrustFrameworkPolicy xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/online/cpim/schemas/2013/06" PolicySchemaVersion="0.3.0.0" TenantId="yourtenant.onmicrosoft.com" PolicyId="B2C_1A_Phone_Email_Base" PublicPolicyUri="http://yourtenant.onmicrosoft.com/B2C_1A_Phone_Email_Base" >
   <BuildingBlocks>
     <ClaimsSchema>
+      <ClaimType Id="newUser">
+        <DisplayName>New signup user</DisplayName>
+        <DataType>boolean</DataType>
+      </ClaimType>    
       <ClaimType Id="tenantId">
         <DisplayName>User's Object's Tenant ID</DisplayName>
         <DataType>string</DataType>
@@ -918,6 +922,7 @@
             <OutputClaim ClaimTypeReferenceId="hasFullProfile" DefaultValue="true" AlwaysUseDefaultValue="true" />
             <OutputClaim ClaimTypeReferenceId="signInNames.phoneNumber" />
             <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
+            <OutputClaim ClaimTypeReferenceId="newUser" DefaultValue="true" />
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -945,6 +950,7 @@
             <OutputClaim ClaimTypeReferenceId="hasFullProfile" DefaultValue="true" AlwaysUseDefaultValue="true" />
             <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
             <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" />
+            <OutputClaim ClaimTypeReferenceId="newUser" DefaultValue="true" />
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="AAD-Common" />
         </TechnicalProfile>
@@ -1127,6 +1133,7 @@
             <OutputClaim ClaimTypeReferenceId="signInNames.phoneNumber" />
             <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
             <OutputClaim ClaimTypeReferenceId="hasFullProfile" />
+            <OutputClaim ClaimTypeReferenceId="newUser" />
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteUsingLogonPhoneNumber" />
@@ -1180,6 +1187,7 @@
             <OutputClaim ClaimTypeReferenceId="hasFullProfile" />
             <OutputClaim ClaimTypeReferenceId="isEmailSignUp" DefaultValue="true" />
             <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
+            <OutputClaim ClaimTypeReferenceId="newUser" />
           </OutputClaims>
           <ValidationTechnicalProfiles>
             <ValidationTechnicalProfile ReferenceId="AAD-UserWriteUsingLogonEmail" />

--- a/scenarios/phone-number-passwordless/SignUpOrSignInWithPhone.xml
+++ b/scenarios/phone-number-passwordless/SignUpOrSignInWithPhone.xml
@@ -16,6 +16,7 @@
         <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />
         <OutputClaim ClaimTypeReferenceId="tenantId" AlwaysUseDefaultValue="true" DefaultValue="{Policy:TenantObjectId}" />
+        <OutputClaim ClaimTypeReferenceId="newUser" />
       </OutputClaims>
       <SubjectNamingInfo ClaimType="sub" />
     </TechnicalProfile>

--- a/scenarios/phone-number-passwordless/SignUpOrSignInWithPhoneOrEmail.xml
+++ b/scenarios/phone-number-passwordless/SignUpOrSignInWithPhoneOrEmail.xml
@@ -17,6 +17,7 @@
         <OutputClaim ClaimTypeReferenceId="strongAuthenticationEmailAddress" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub" />
         <OutputClaim ClaimTypeReferenceId="tenantId" AlwaysUseDefaultValue="true" DefaultValue="{Policy:TenantObjectId}" />
+        <OutputClaim ClaimTypeReferenceId="newUser" />        
       </OutputClaims>
       <SubjectNamingInfo ClaimType="sub" />
     </TechnicalProfile>


### PR DESCRIPTION
Added definition of newUser claim type and set it to true in the two technical profiles creating a user: from phone number or from email address. Passed the claim value to downstream technical profiles and the two relying parties supporting signup.