### PR TITLE
Updated TrustFrameworkBase.xml

### DIFF
--- a/LocalAccounts/TrustFrameworkBase.xml
+++ b/LocalAccounts/TrustFrameworkBase.xml
@@ -429,8 +429,8 @@
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="signInName" PartnerClaimType="username" Required="true" />
             <InputClaim ClaimTypeReferenceId="password" Required="true" />
-            <InputClaim ClaimTypeReferenceId="grant_type" DefaultValue="password" />
-            <InputClaim ClaimTypeReferenceId="scope" DefaultValue="openid" />
+            <InputClaim ClaimTypeReferenceId="grant_type" DefaultValue="password" AlwaysUseDefaultValue="true" />
+            <InputClaim ClaimTypeReferenceId="scope" DefaultValue="openid" AlwaysUseDefaultValue="true" />
             <InputClaim ClaimTypeReferenceId="nca" PartnerClaimType="nca" DefaultValue="1" />
           </InputClaims>
           <OutputClaims>


### PR DESCRIPTION
Updated TrustFrameworkBase.xml login-NonInteractive technical profile to always use default value for grant_type and scope.
Recent ability to use BearerToken to secure APIs (https://docs.microsoft.com/en-us/azure/active-directory-b2c/secure-rest-api?tabs=windows&pivots=b2c-custom-policy) means that users will be changing the grant_type and scope when following the documentation. This can cause an "Invalid username or password." to be thrown by login-NonInteractive in some cases, for example JIT migration approaches.

This patch means login-NonInteractive will always use the default value for scope and grant_type.