### PR TITLE
Aligned DisplayControl string IDs to match built-in user flows.

### DIFF
--- a/Display Controls Starterpack/LocalAccounts/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/LocalAccounts/TrustFrameworkBase.xml
@@ -291,7 +291,7 @@
       <ClaimType Id="verificationCode">
         <DisplayName>Verification Code</DisplayName>
         <DataType>string</DataType>
-        <UserHelpText>Enter your SMS verification code</UserHelpText>
+        <UserHelpText>Enter your verification code</UserHelpText>
         <UserInputType>TextBox</UserInputType>
       </ClaimType>
 

--- a/Display Controls Starterpack/LocalAccounts/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/LocalAccounts/TrustFrameworkBase.xml
@@ -413,7 +413,7 @@
     </ContentDefinitions>
 
     <DisplayControls>
-      <DisplayControl Id="emailControl" UserInterfaceControlType="VerificationControl">
+      <DisplayControl Id="emailVerificationControl" UserInterfaceControlType="VerificationControl">
         <DisplayClaims>
           <DisplayClaim ClaimTypeReferenceId="email" Required="true" />
           <DisplayClaim ClaimTypeReferenceId="verificationCode" ControlClaimType="VerificationCode" Required="true" />
@@ -681,7 +681,7 @@
             <InputClaim ClaimTypeReferenceId="email" />
           </InputClaims>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
             <DisplayClaim ClaimTypeReferenceId="newPassword" Required="true" />
             <DisplayClaim ClaimTypeReferenceId="reenterPassword" Required="true" />
 
@@ -753,7 +753,7 @@
           </CryptographicKeys>
           <IncludeInSso>false</IncludeInSso>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
           </DisplayClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="email" />

--- a/Display Controls Starterpack/LocalAccounts/TrustFrameworkLocalization.xml
+++ b/Display Controls Starterpack/LocalAccounts/TrustFrameworkLocalization.xml
@@ -130,15 +130,15 @@
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="button_cancel">Cancel</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>
@@ -183,15 +183,15 @@
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfClaimsTransformationBooleanValueIsNotEqual">Your account has been locked. Contact your support person to unlock it, then try again.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>

--- a/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkBase.xml
@@ -474,7 +474,7 @@
     </ContentDefinitions>
 
     <DisplayControls>
-      <DisplayControl Id="emailControl" UserInterfaceControlType="VerificationControl">
+      <DisplayControl Id="emailVerificationControl" UserInterfaceControlType="VerificationControl">
         <DisplayClaims>
           <DisplayClaim ClaimTypeReferenceId="email" Required="true" />
           <DisplayClaim ClaimTypeReferenceId="verificationCode" ControlClaimType="VerificationCode" Required="true" />
@@ -903,7 +903,7 @@
             <InputClaim ClaimTypeReferenceId="email" />
           </InputClaims>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
             <DisplayClaim ClaimTypeReferenceId="newPassword" Required="true" />
             <DisplayClaim ClaimTypeReferenceId="reenterPassword" Required="true" />
 
@@ -975,7 +975,7 @@
           </CryptographicKeys>
           <IncludeInSso>false</IncludeInSso>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
           </DisplayClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="email" />

--- a/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkBase.xml
@@ -304,7 +304,7 @@
       <ClaimType Id="verificationCode">
         <DisplayName>Verification Code</DisplayName>
         <DataType>string</DataType>
-        <UserHelpText>Enter your SMS verification code</UserHelpText>
+        <UserHelpText>Enter your verification code</UserHelpText>
         <UserInputType>TextBox</UserInputType>
       </ClaimType>
 

--- a/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkLocalization.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccounts/TrustFrameworkLocalization.xml
@@ -132,15 +132,15 @@
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="button_cancel">Cancel</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>
@@ -196,15 +196,15 @@
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfClaimsTransformationBooleanValueIsNotEqual">Your account has been locked. Contact your support person to unlock it, then try again.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>

--- a/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -522,7 +522,7 @@
     </ContentDefinitions>
 
     <DisplayControls>
-      <DisplayControl Id="emailControl" UserInterfaceControlType="VerificationControl">
+      <DisplayControl Id="emailVerificationControl" UserInterfaceControlType="VerificationControl">
         <DisplayClaims>
           <DisplayClaim ClaimTypeReferenceId="email" Required="true" />
           <DisplayClaim ClaimTypeReferenceId="verificationCode" ControlClaimType="VerificationCode" Required="true" />
@@ -1008,7 +1008,7 @@
             <InputClaim ClaimTypeReferenceId="email" />
           </InputClaims>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
             <DisplayClaim ClaimTypeReferenceId="newPassword" Required="true" />
             <DisplayClaim ClaimTypeReferenceId="reenterPassword" Required="true" />
 
@@ -1080,7 +1080,7 @@
           </CryptographicKeys>
           <IncludeInSso>false</IncludeInSso>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="emailControl" />
+            <DisplayClaim DisplayControlReferenceId="emailVerificationControl" />
           </DisplayClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="email" />

--- a/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkBase.xml
@@ -331,7 +331,7 @@
       <ClaimType Id="verificationCode">
         <DisplayName>Verification Code</DisplayName>
         <DataType>string</DataType>
-        <UserHelpText>Enter your SMS verification code</UserHelpText>
+        <UserHelpText>Enter your verification code</UserHelpText>
         <UserInputType>TextBox</UserInputType>
       </ClaimType>
 

--- a/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkLocalization.xml
+++ b/Display Controls Starterpack/SocialAndLocalAccountsWithMfa/TrustFrameworkLocalization.xml
@@ -139,15 +139,15 @@
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="button_cancel">Cancel</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>
@@ -203,15 +203,15 @@
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfClaimsTransformationBooleanValueIsNotEqual">Your account has been locked. Contact your support person to unlock it, then try again.</LocalizedString>
           <LocalizedString ElementType="UxElement" StringId="required_field">This information is required.</LocalizedString>
           <!-- Display control UI elements-->
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_code">Send verification code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_verify_code">Verify code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_send_new_code">Send new code</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="emailControl" StringId="but_change_claims">Change e-mail</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="intro_msg">Verification is necessary. Please click Send button.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_send_code_msg">Verification code has been sent to your inbox. Please copy it to the input box below.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_send_code_msg">We are having trouble verifying your email address. Please enter a valid email address and try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="success_verify_code_msg">E-mail address verified. You can now continue.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="failure_verify_code_msg">We are having trouble verifying your email address. Please try again.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_code">Send verification code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_verify_code">Verify code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_send_new_code">Send new code</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="emailVerificationControl" StringId="but_change_claims">Change e-mail</LocalizedString>
           <!-- Display control errors -->
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInternalError">We are having trouble verifying your email address. Please try again later.</LocalizedString>
           <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfThrottled">There have been too many requests to verify this email address. Please wait a while, then try again.</LocalizedString>

--- a/scenarios/phone-number-passwordless/Phone_Email_Base.xml
+++ b/scenarios/phone-number-passwordless/Phone_Email_Base.xml
@@ -322,7 +322,7 @@
       <ClaimType Id="verificationCode">
         <DisplayName>Verification Code</DisplayName>
         <DataType>string</DataType>
-        <UserHelpText>Enter your SMS verification code</UserHelpText>
+        <UserHelpText>Enter your verification code</UserHelpText>
         <UserInputType>TextBox</UserInputType>
         <!--Restriction>
           <Pattern RegularExpression="^[0-9]{1,15}$" HelpText="Please enter digits" />

--- a/scenarios/phone-number-passwordless/Phone_Email_Base.xml
+++ b/scenarios/phone-number-passwordless/Phone_Email_Base.xml
@@ -803,11 +803,11 @@
           <!-- The following elements will display a message and two links at the bottom of the signup page. 
           For policies that you intend to show to users in the United States, we suggest displaying the following text. Replace the content of the disclaimer_link_X_url elements with links to your organization's privacy statement and terms and conditions. 
           Remove any of these lines if you do not wish to display them.  -->
-          <LocalizedString ElementType="DisplayControl" ElementId="phoneControl" StringId="disclaimer_msg_intro">By providing your phone number, you consent to receiving a one-time passcode sent by text message to help you sign into {insert your application name}. Standard messsage and data rates may apply.</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="phoneControl" StringId="disclaimer_link_1_text">Privacy Statement</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="phoneControl" StringId="disclaimer_link_1_url">{insert your privacy statement URL}</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="phoneControl" StringId="disclaimer_link_2_text">Terms and Conditions</LocalizedString>
-          <LocalizedString ElementType="DisplayControl" ElementId="phoneControl" StringId="disclaimer_link_2_url">{insert your terms and conditions URL}</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="phoneVerificationControl" StringId="disclaimer_msg_intro">By providing your phone number, you consent to receiving a one-time passcode sent by text message to help you sign into {insert your application name}. Standard messsage and data rates may apply.</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="phoneVerificationControl" StringId="disclaimer_link_1_text">Privacy Statement</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="phoneVerificationControl" StringId="disclaimer_link_1_url">{insert your privacy statement URL}</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="phoneVerificationControl" StringId="disclaimer_link_2_text">Terms and Conditions</LocalizedString>
+          <LocalizedString ElementType="DisplayControl" ElementId="phoneVerificationControl" StringId="disclaimer_link_2_url">{insert your terms and conditions URL}</LocalizedString>
         </LocalizedStrings>
       </LocalizedResources>
       <LocalizedResources Id="phoneInput.en">
@@ -835,7 +835,7 @@
       </LocalizedResources>
     </Localization>
     <DisplayControls>
-      <DisplayControl Id="phoneControl" UserInterfaceControlType="VerificationControl">
+      <DisplayControl Id="phoneVerificationControl" UserInterfaceControlType="VerificationControl">
         <InputClaims>
           <InputClaim ClaimTypeReferenceId="nationalNumber" />
           <InputClaim ClaimTypeReferenceId="countryCode" />
@@ -1128,7 +1128,7 @@
             <Key Id="issuer_secret" StorageReferenceId="B2C_1A_TokenSigningKeyContainer" />
           </CryptographicKeys>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="phoneControl" />
+            <DisplayClaim DisplayControlReferenceId="phoneVerificationControl" />
           </DisplayClaims>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" />
@@ -1158,7 +1158,7 @@
             <InputClaimsTransformation ReferenceId="CreateUserPrincipalName" />
           </InputClaimsTransformations>
           <DisplayClaims>
-            <DisplayClaim DisplayControlReferenceId="phoneControl" />
+            <DisplayClaim DisplayControlReferenceId="phoneVerificationControl" />
             <DisplayClaim ClaimTypeReferenceId="displayName" />
             <DisplayClaim ClaimTypeReferenceId="givenName" />
             <DisplayClaim ClaimTypeReferenceId="surName" />


### PR DESCRIPTION
Changes made to align string IDs in user flows and IEF policies. This means string IDs do not need updating in custom templates if being shared between built-in flows and custom policies.

1. Made verificationCode user help text generic as it is used for both email and SMS verification
2. Changed emailControl display control ID to emailVerificationControl - This now matches the string ID in the built-in user flows meaning custom templates will have the same string ID in user flows and IEF policies.
3. Changed phoneControl display control ID to phoneVerificationControl - This now matches the string ID in the built-in user flows meaning custom templates will have the same string ID in user flows and IEF policies.