### PR TITLE
Fixed "invalid pattern" error when using libxml2 to load the xsd file

### DIFF
--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -3700,7 +3700,7 @@
       <xs:pattern value="(https://)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="DeploymentModeType">
     <xs:annotation>
       <xs:documentation>
@@ -3809,5 +3809,5 @@
       <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>
-  
+
 </xs:schema>

--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -3685,8 +3685,8 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="^(http://|https://|~/)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)$" />
-      <xs:pattern value="^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\/\-.:=@;$_!*'%\/?#]+$" />
+      <xs:pattern value="(http://|https://|~/)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)" />
+      <xs:pattern value="urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-\.:=@;$_!*'%/?#]+" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -1663,7 +1663,7 @@
       <xs:documentation>
         Represents a Claims Provider, along with its technical profiles.
       </xs:documentation>
-    </xs:annotation>    
+    </xs:annotation>
     <xs:sequence>
       <xs:element minOccurs="0" maxOccurs="1" name="Domains">
         <xs:annotation>
@@ -1912,7 +1912,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <!--New password complexity schema xsd-->
   <xs:complexType name="PredicateGroups">
     <xs:annotation>
@@ -1924,7 +1924,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="PredicateGroup" type="tfp:PredicateGroup" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateGroup">
     <xs:annotation>
       <xs:documentation>
@@ -1949,7 +1949,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateValidation">
     <xs:annotation>
       <xs:documentation>
@@ -1967,7 +1967,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateValidationReference">
     <xs:annotation>
       <xs:documentation>
@@ -2041,7 +2041,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="JourneyList">
     <xs:annotation>
       <xs:documentation>
@@ -2052,7 +2052,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="Candidate" type="tfp:Candidate" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:complexType name="Candidate">
     <xs:annotation>
       <xs:documentation>
@@ -3078,7 +3078,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="ErrorHandlingAction">
     <xs:annotation>
       <xs:documentation>
@@ -3191,7 +3191,7 @@
       <xs:enumeration value="OnItemAbsenceInStringCollectionClaim" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="ClaimsProviderSelectionDisplayOption">
     <xs:annotation>
       <xs:documentation>
@@ -3448,7 +3448,7 @@
       <xs:enumeration value="userIdentity"/>
       <xs:enumeration value="phoneNumber"/>
       <xs:enumeration value="objectIdentityCollection"/>
-      <xs:enumeration value="objectIdentity"/>      
+      <xs:enumeration value="objectIdentity"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -3471,7 +3471,7 @@
 	  <xs:enumeration value="Paragraph"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="UserInterfaceControlType">
     <xs:annotation>
       <xs:documentation>
@@ -3685,7 +3685,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="(http://|https://|~/)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)" />
+      <xs:pattern value="((http://)|(https://)|(~/))([\w\.,@?\^=%&amp;:~+#\-_$!’\(\);]+/)*([\w\.,@?\^=%&amp;:~+#\-_$!’\(\);]+/?)" />
       <xs:pattern value="urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-\.:=@;$_!*'%/?#]+" />
     </xs:restriction>
   </xs:simpleType>
@@ -3697,10 +3697,10 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="^(https://)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)$" />
+      <xs:pattern value="(https://)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="DeploymentModeType">
     <xs:annotation>
       <xs:documentation>
@@ -3773,7 +3773,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="SubJourneyTYPE">
     <xs:annotation>
       <xs:documentation>
@@ -3809,5 +3809,5 @@
       <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>
-	
+
 </xs:schema>

--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -1663,7 +1663,7 @@
       <xs:documentation>
         Represents a Claims Provider, along with its technical profiles.
       </xs:documentation>
-    </xs:annotation>
+    </xs:annotation>    
     <xs:sequence>
       <xs:element minOccurs="0" maxOccurs="1" name="Domains">
         <xs:annotation>
@@ -1912,7 +1912,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-
+  
   <!--New password complexity schema xsd-->
   <xs:complexType name="PredicateGroups">
     <xs:annotation>
@@ -1924,7 +1924,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="PredicateGroup" type="tfp:PredicateGroup" />
     </xs:sequence>
   </xs:complexType>
-
+  
   <xs:complexType name="PredicateGroup">
     <xs:annotation>
       <xs:documentation>
@@ -1949,7 +1949,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-
+  
   <xs:complexType name="PredicateValidation">
     <xs:annotation>
       <xs:documentation>
@@ -1967,7 +1967,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-
+  
   <xs:complexType name="PredicateValidationReference">
     <xs:annotation>
       <xs:documentation>
@@ -2041,7 +2041,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-
+  
   <xs:complexType name="JourneyList">
     <xs:annotation>
       <xs:documentation>
@@ -2052,7 +2052,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="Candidate" type="tfp:Candidate" />
     </xs:sequence>
   </xs:complexType>
-
+  
   <xs:complexType name="Candidate">
     <xs:annotation>
       <xs:documentation>
@@ -3078,7 +3078,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-
+  
   <xs:simpleType name="ErrorHandlingAction">
     <xs:annotation>
       <xs:documentation>
@@ -3191,7 +3191,7 @@
       <xs:enumeration value="OnItemAbsenceInStringCollectionClaim" />
     </xs:restriction>
   </xs:simpleType>
-
+  
   <xs:simpleType name="ClaimsProviderSelectionDisplayOption">
     <xs:annotation>
       <xs:documentation>
@@ -3448,7 +3448,7 @@
       <xs:enumeration value="userIdentity"/>
       <xs:enumeration value="phoneNumber"/>
       <xs:enumeration value="objectIdentityCollection"/>
-      <xs:enumeration value="objectIdentity"/>
+      <xs:enumeration value="objectIdentity"/>      
     </xs:restriction>
   </xs:simpleType>
 
@@ -3471,7 +3471,7 @@
 	  <xs:enumeration value="Paragraph"/>
     </xs:restriction>
   </xs:simpleType>
-
+  
   <xs:simpleType name="UserInterfaceControlType">
     <xs:annotation>
       <xs:documentation>
@@ -3700,7 +3700,7 @@
       <xs:pattern value="(https://)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)" />
     </xs:restriction>
   </xs:simpleType>
-
+  
   <xs:simpleType name="DeploymentModeType">
     <xs:annotation>
       <xs:documentation>
@@ -3773,7 +3773,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-
+  
   <xs:simpleType name="SubJourneyTYPE">
     <xs:annotation>
       <xs:documentation>
@@ -3809,5 +3809,5 @@
       <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>
-
+  
 </xs:schema>

--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -1663,7 +1663,7 @@
       <xs:documentation>
         Represents a Claims Provider, along with its technical profiles.
       </xs:documentation>
-    </xs:annotation>    
+    </xs:annotation>
     <xs:sequence>
       <xs:element minOccurs="0" maxOccurs="1" name="Domains">
         <xs:annotation>
@@ -1912,7 +1912,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <!--New password complexity schema xsd-->
   <xs:complexType name="PredicateGroups">
     <xs:annotation>
@@ -1924,7 +1924,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="PredicateGroup" type="tfp:PredicateGroup" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateGroup">
     <xs:annotation>
       <xs:documentation>
@@ -1949,7 +1949,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateValidation">
     <xs:annotation>
       <xs:documentation>
@@ -1967,7 +1967,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="PredicateValidationReference">
     <xs:annotation>
       <xs:documentation>
@@ -2041,7 +2041,7 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:complexType name="JourneyList">
     <xs:annotation>
       <xs:documentation>
@@ -2052,7 +2052,7 @@
       <xs:element minOccurs="1" maxOccurs="unbounded" name="Candidate" type="tfp:Candidate" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:complexType name="Candidate">
     <xs:annotation>
       <xs:documentation>
@@ -3078,7 +3078,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="ErrorHandlingAction">
     <xs:annotation>
       <xs:documentation>
@@ -3191,7 +3191,7 @@
       <xs:enumeration value="OnItemAbsenceInStringCollectionClaim" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="ClaimsProviderSelectionDisplayOption">
     <xs:annotation>
       <xs:documentation>
@@ -3448,7 +3448,7 @@
       <xs:enumeration value="userIdentity"/>
       <xs:enumeration value="phoneNumber"/>
       <xs:enumeration value="objectIdentityCollection"/>
-      <xs:enumeration value="objectIdentity"/>      
+      <xs:enumeration value="objectIdentity"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -3471,7 +3471,7 @@
 	  <xs:enumeration value="Paragraph"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="UserInterfaceControlType">
     <xs:annotation>
       <xs:documentation>
@@ -3773,7 +3773,7 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="SubJourneyTYPE">
     <xs:annotation>
       <xs:documentation>


### PR DESCRIPTION
I'm currently working on a template system, where I generate the XML files, and I wanted to validate them. I inderictly use `libxml2`  from python via `lxml` to validate the generated XML files with the `TrustFrameowrkPolicy_0.3.0.0.xsd` schema file, but I get errors saying that line `3689` of the xsd file contains an invalid regular expression pattern.

You can also reproduce the issue with the command line tools of `libxml2`:
1. On ubuntu: `sudo apt install libxml2-utils`
2. `xmllint --schema TrustFrameworkPolicy_0.3.0.0.xsd TrustFrameworkBase.xml`

With python you can reproduce it the following way:
1. Python 3.8+ is required.
2. `pip install lxml==4.8.0 cython==0.29.28`
3. Create a python file `repro.py`
4. Write the following in the `repro.py` file:
```py
from lxml import etree

with open("TrustFrameworkPolicy_0.3.0.0.xsd") as f:
    xmlschema_doc = etree.parse(f)
    xmlschema = etree.XMLSchema(xmlschema_doc)

with open("TrustFrameworkBase.xml"):
    doc = etree.parse(xml_file)
    xmlschema.assertValid(doc)
```

This PR addresses the issue. I need to test this with VSCode too, but I'm not using it on day to day basis, so it would be great if somebody could test this or point me to the right direction so I can set it up myself.

P.S.: Sorry about the whitespace changes.