### PR TITLE
Fix UAE country code in phone-number-passwordless scenario

### DIFF
--- a/scenarios/phone-number-passwordless/Phone_Email_Base.xml
+++ b/scenarios/phone-number-passwordless/Phone_Email_Base.xml
@@ -303,7 +303,7 @@
           <Enumeration Text="Tuvalu(+688)" Value="TV" />
           <Enumeration Text="Uganda(+256)" Value="UG" />
           <Enumeration Text="Ukraine(+380)" Value="UA" />
-          <Enumeration Text="United Arab Emirates(+971)" Value="UA" />
+          <Enumeration Text="United Arab Emirates(+971)" Value="AE" />
           <Enumeration Text="United Kingdom(+44)" Value="GB" />
           <Enumeration Text="United States(+1)" Value="US" />
           <Enumeration Text="Virgin Islands, U.S.(+1340)" Value="VI" />


### PR DESCRIPTION
UAE was the same as Ukraine (UA)
Changed it to AE as per https://www.iban.com/country-codes