### PR TITLE
fix: make TrustFrameworkPolicy_0.3.0.0.xsd valid

### DIFF
--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -3686,7 +3686,7 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="^(http://|https://|~/)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)$" />
-      <xs:pattern value="^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\/\-.:=@;$_!*'%\/?#]+$" />
+      <xs:pattern value="^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%?#]+$" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/TrustFrameworkPolicy_0.3.0.0.xsd
+++ b/TrustFrameworkPolicy_0.3.0.0.xsd
@@ -3686,7 +3686,7 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="^(http://|https://|~/)([\w.,@?^=%&amp;:~+#\-_$!’();]+/)*([\w.,@?^=%&amp;:~+#\-_$!’();]+/?)$" />
-      <xs:pattern value="^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%?#]+$" />
+      <xs:pattern value="^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,/\-.:=@;$_!*'%?#]+$" />
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
in the current state, `<xs:simpleType name="ContentUriTYPE">` does not allow to have the literal `/` included as part of the `urn` resource syntax.
This PR fixes the respective urn regex.